### PR TITLE
下記のバグ修正

### DIFF
--- a/Controller/MultidatabaseContentsController.php
+++ b/Controller/MultidatabaseContentsController.php
@@ -457,7 +457,7 @@ class MultidatabaseContentsController extends MultidatabasesAppController {
 		);
 
 		$this->set('cancelUrl', NetCommonsUrl::backToIndexUrl());
-		$this->set('multidatabaseContents', $this->Paginator->paginate());
+		$this->set('multidatabaseContents', $this->Paginator->paginate('MultidatabaseContent'));
 		$this->set('viewMode', 'list');
 		if (!empty($query)) {
 			$this->render('search_results');
@@ -547,7 +547,7 @@ class MultidatabaseContentsController extends MultidatabasesAppController {
 
 		$this->MultidatabaseContent->recursive = 0;
 		$this->MultidatabaseContent->Behaviors->load('ContentComments.ContentComment');
-		$this->set('multidatabaseContents', $this->Paginator->paginate());
+		$this->set('multidatabaseContents', $this->Paginator->paginate('MultidatabaseContent'));
 		$this->MultidatabaseContent->Behaviors->unload('ContentComments.ContentComment');
 		$this->MultidatabaseContent->recursive = -1;
 


### PR DESCRIPTION
NetCommonsAppControllerでmergeVarsをすることで、親クラスのuses,components,helpersがマージされるようになり、usesの順番がくるってしまい、第一引数を省略していたため、paginateでエラーになるようになった。そもそも、第一引数を省略すること自体間違っているため、省略せずにセットするように修正