### PR TITLE
refs: /NetCommons3/NetCommons3/issues/1259

### DIFF
--- a/View/Elements/MultidatabaseContents/view/view_content_group_c1.ctp
+++ b/View/Elements/MultidatabaseContents/view/view_content_group_c1.ctp
@@ -15,7 +15,7 @@
 	<table class="table table-bordered">
 		<?php foreach ($gMetadatas as $key => $metadata): ?>
 			<tr>
-				<th style="width:<?php echo $headerMaxLength; ?>rem;">
+				<th>
 					<?php if ($metadata['is_visible_field_name'] === 1): ?>
 						<?php echo $metadata['name']; ?>
 					<?php endif; ?>

--- a/View/Elements/MultidatabaseContents/view/view_content_group_c2.ctp
+++ b/View/Elements/MultidatabaseContents/view/view_content_group_c2.ctp
@@ -15,7 +15,7 @@
 	<table class="table table-bordered">
 		<?php foreach ($gMetadatas as $key => $metadata): ?>
 			<tr>
-				<th style="width:<?php echo $headerMaxLength; ?>rem;">
+				<th>
 					<?php if ($metadata['is_visible_field_name'] === 1): ?>
 						<?php echo $metadata['name']; ?>
 					<?php endif; ?>

--- a/webroot/css/style.css
+++ b/webroot/css/style.css
@@ -18,19 +18,26 @@
 
 }
 
-.multidatabase-content-list article footer,
-.multidatabase-content-detail article footer {
-	margin-top: 0 !important;
-	padding-bottom: 20px !important;
+.multidatabase-content-list table.table.table-bordered th,
+.multidatabase-content-detail table.table.table-bordered th {
+	width: 20%;
+	word-break: break-all;
+	text-align: left;
+	line-height: 1.3;
+	vertical-align: middle;
+	font-size: smaller;
+}
+
+.frame.nc-content .multidatabase-content-list article footer,
+.frame.nc-content .multidatabase-content-detail article footer,
+.frame.nc-content-list .multidatabase-content-list article footer,
+.frame.nc-content-list .multidatabase-content-detail article footer {
+	margin-top: -10px;
+	margin-bottom: 35px;
 }
 
 .multidatabase-content-list article:last-child footer {
 	padding-bottom:0;
-}
-
-.multidatabase-contents table td,
-.multidatabase-contents table th {
-	padding:5px !important;
 }
 
 .multidatabase-contents table th {


### PR DESCRIPTION
汎用DBの表のTHの幅が一番長いラベルの文字数分になっているのをやめました。
TH幅は表の20%に限定しています。
これで表の値が書かれている欄が圧迫されることがなくなると思います。