### PR TITLE
fix:絞り込みと検索の修正

### DIFF
--- a/Model/MultidatabaseContentSearch.php
+++ b/Model/MultidatabaseContentSearch.php
@@ -133,7 +133,7 @@ class MultidatabaseContentSearch extends MultidatabasesAppModel {
 							);
 						break;
 					case 'checkbox':
-						$result += $this->MultidatabaseContentSearchCond->getCondSelCheck(
+						$result[] = $this->MultidatabaseContentSearchCond->getCondSelCheck(
 								$metadata['selections'], $values, $valueKey
 							);
 						break;

--- a/Model/MultidatabaseContentSearchCond.php
+++ b/Model/MultidatabaseContentSearchCond.php
@@ -57,20 +57,28 @@ class MultidatabaseContentSearchCond extends MultidatabasesAppModel {
  */
 	public function getCondStartEndDt($query) {
 		$conditions = [];
+
+		//サーバタイムゾーンの日時に変換
+		$date = new DateTime($query['start_dt']['value']);
+		$createdStart = (new NetCommonsTime())->toServerDatetime($date->format('Y-m-d H:i:s'));
+		$date = new DateTime($query['end_dt']['value']);
+		$date->modify('+59 second');
+		$createdEnd = (new NetCommonsTime())->toServerDatetime($date->format('Y-m-d H:i:s'));
+
 		if (
 			!empty($query['start_dt']['value']) &&
 			!empty($query['end_dt']['value'])
 		) {
 			$conditions['MultidatabaseContent.created between ? and ?'] = [
-				$query['start_dt']['value'],
-				$query['end_dt']['value']
+				$createdStart,
+				$createdEnd
 			];
 		} else {
 			if (!empty($query['start_dt']['value'])) {
-				$conditions['MultidatabaseContent.created <='] = $query['start_dt']['value'];
+				$conditions['MultidatabaseContent.created >='] = $createdStart;
 			}
 			if (!empty($query['end_dt']['value'])) {
-				$conditions['MultidatabaseContent.created >='] = $query['end_dt']['value'];
+				$conditions['MultidatabaseContent.created <='] = $createdEnd;
 			}
 		}
 

--- a/View/Helper/MultidatabaseContentViewHelper.php
+++ b/View/Helper/MultidatabaseContentViewHelper.php
@@ -215,6 +215,7 @@ class MultidatabaseContentViewHelper extends AppHelper {
 	public function dropDownToggleSelect($metadatas, $viewType = 'index') {
 		$params = $this->_View->Paginator->params;
 		$named = $params['named'];
+		$named['page'] = 1;
 		$url = $named;
 		$result = '';
 

--- a/View/MultidatabaseContents/search.ctp
+++ b/View/MultidatabaseContents/search.ctp
@@ -48,15 +48,6 @@ echo $this->NetCommonsHtml->css([
 						echo $this->NetCommonsForm->input('type', $options);
 					?>
 				</div>
-				<?php // 作成者（ハンドル） ?>
-				<div>
-					<?php
-						$options = [
-							'label' => __d('multidatabases', 'Create user')
-						];
-						echo $this->NetCommonsForm->input('create_user', $options);
-					?>
-				</div>
 				<?php // 作成日時 ?>
 				<div>
 					<div class="form-group">


### PR DESCRIPTION
以下の修正を行いました、よろしければマージしてください。

・2ページ目以降で絞り込みのプルダウンを変更した場合に表示しているページ数より少なくなるとエラーになるため、絞り込みのプルダウンを変更した際に1ページ目を表示するように修正
・選択式（複数）の項目が複数存在する場合に、絞り込み条件が一つしか有効にならない障害の修正
・検索画面の作成日時をサーバタイムゾーンの日時に変換して検索するように修正
・検索画面の作成日時を片方しか入力していない場合の不等号が逆になっている障害の修正
・検索画面の作成者を入力しても検索が行えず、作成者で検索する場面も少ないと考えられるため、作成者の検索項目を削除